### PR TITLE
Feature 2209 AC, 2208 Ocotpus, fix rename script

### DIFF
--- a/ini/luxuri.ini
+++ b/ini/luxuri.ini
@@ -256,6 +256,12 @@ extends       = common_avr8
 board         = megaatmega2560
 build_flags = ${common.build_flags} -DMachineTLD3P -DDriver2209 -DTitanExtruder -DPOWER_LOSS_TRIGGER_BY_PIN -DPSU_CONTROL
 
+[env:D3P_2209_Titan_OpticalY_ACBed]
+platform      = atmelavr
+extends       = common_avr8
+board         = megaatmega2560
+build_flags = ${common.build_flags} -DMachineTLD3P -DDriver2209 -DTitanExtruder -DOpticalY -DACBed -DPOWER_LOSS_TRIGGER_BY_PIN -DPSU_CONTROL
+
 [env:D3P_2209_Titan_BLTouch]
 platform      = atmelavr
 extends       = common_avr8
@@ -297,34 +303,37 @@ build_flags = ${common.build_flags} -DMachineTLD3P -DTGCustom_2209_Titan -DPOWER
 
 # BigTreeTech Octopus V1.0 and V1.1 (STM32F446ZET6 ARM Cortex-M4)
 #
-[env:D3P_OCTOPUS_Driver2209BTT_OpticalY_BMGV2_BLTouch]
+[env:D3P_OCTOPUS_Driver2208_UART]
 platform           = ${common_stm32.platform}
 extends            = stm32_variant
 board              = marlin_BigTree_Octopus_v1
 board_build.offset = 0x8000
-build_flags       = ${stm32_variant.build_flags} -DMachineTLD3P -DOCTOPUS -DDriver2209BTT -DOpticalY -DBMGExtruderV2 -DBL_Touch 
-  -DSTM32F446_5VX -DUSE_USB_HS_IN_FS
-
-[env:D3P_OCTOPUS_Driver2209BTT_OpticalY_BMGV2_BLTouch_LCDmini12864]
-platform           = ${common_stm32.platform}
-extends            = stm32_variant
-board              = marlin_BigTree_Octopus_v1
-board_build.offset = 0x8000
-build_flags       = ${stm32_variant.build_flags} -DMachineTLD3P -DOCTOPUS -DDriver2209BTT -DOpticalY -DBMGExtruderV2 -DBL_Touch -DLCDmini12864
-  -DSTM32F446_5VX -DUSE_USB_HS_IN_FS
-
-[env:D3P_OCTOPUS_Driver2209BTT_OpticalY_BMGV3_BLTouch_LCDmini12864]
-platform           = ${common_stm32.platform}
-extends            = stm32_variant
-board              = marlin_BigTree_Octopus_v1
-board_build.offset = 0x8000
-build_flags       = ${stm32_variant.build_flags} -DMachineTLD3P -DOCTOPUS -DDriver2209BTT -DOpticalY -DBMGExtruderV3 -DBL_Touch -DLCDmini12864
-  -DSTM32F446_5VX -DUSE_USB_HS_IN_FS
+build_flags       = ${stm32_variant.build_flags} -DMachineTLD3P -DOCTOPUS -DDriver2208_UART -DSTM32F446_5VX -DUSE_USB_HS_IN_FS
 
 [env:D3P_OCTOPUS_Driver2208_UART_BLTouch_LCD_BTT_TFT]
 platform           = ${common_stm32.platform}
 extends            = stm32_variant
 board              = marlin_BigTree_Octopus_v1
 board_build.offset = 0x8000
-build_flags       = ${stm32_variant.build_flags} -DMachineTLD3P -DOCTOPUS -DDriver2208_UART -DBL_Touch -DLCD_BTT_TFT
-  -DSTM32F446_5VX -DUSE_USB_HS_IN_FS
+build_flags       = ${stm32_variant.build_flags} -DMachineTLD3P -DOCTOPUS -DDriver2208_UART -DBL_Touch -DLCD_BTT_TFT -DSTM32F446_5VX -DUSE_USB_HS_IN_FS
+
+[env:D3P_OCTOPUS_Driver2209BTT_OpticalY_BMGV2_BLTouch]
+platform           = ${common_stm32.platform}
+extends            = stm32_variant
+board              = marlin_BigTree_Octopus_v1
+board_build.offset = 0x8000
+build_flags       = ${stm32_variant.build_flags} -DMachineTLD3P -DOCTOPUS -DDriver2209BTT -DOpticalY -DBMGExtruderV2 -DBL_Touch -DSTM32F446_5VX -DUSE_USB_HS_IN_FS
+
+[env:D3P_OCTOPUS_Driver2209BTT_OpticalY_BMGV2_BLTouch_LCDmini12864]
+platform           = ${common_stm32.platform}
+extends            = stm32_variant
+board              = marlin_BigTree_Octopus_v1
+board_build.offset = 0x8000
+build_flags       = ${stm32_variant.build_flags} -DMachineTLD3P -DOCTOPUS -DDriver2209BTT -DOpticalY -DBMGExtruderV2 -DBL_Touch -DLCDmini12864 -DSTM32F446_5VX -DUSE_USB_HS_IN_FS
+
+[env:D3P_OCTOPUS_Driver2209BTT_OpticalY_BMGV3_BLTouch_LCDmini12864]
+platform           = ${common_stm32.platform}
+extends            = stm32_variant
+board              = marlin_BigTree_Octopus_v1
+board_build.offset = 0x8000
+build_flags       = ${stm32_variant.build_flags} -DMachineTLD3P -DOCTOPUS -DDriver2209BTT -DOpticalY -DBMGExtruderV3 -DBL_Touch -DLCDmini12864 -DSTM32F446_5VX -DUSE_USB_HS_IN_FS

--- a/platformio.ini
+++ b/platformio.ini
@@ -53,16 +53,18 @@ default_envs =
   D3P_2209_OpticalY
   D3P_2209_OpticalY_BLTouch
   D3P_2209_Titan
+  D3P_2209_Titan_OpticalY_ACBed
   D3P_2209_Titan_BLTouch
   D3P_2209_Titan_BLTouch_ACBed
   D3P_2209_OpticalY_Titan
   D3S_2209_Titan
   D6P_2209_OpticalY
   ; BTT OCTOPUS Builds
+  D3P_OCTOPUS_Driver2208_UART
+  D3P_OCTOPUS_Driver2208_UART_BLTouch_LCD_BTT_TFT
   D3P_OCTOPUS_Driver2209BTT_OpticalY_BMGV2_BLTouch
   D3P_OCTOPUS_Driver2209BTT_OpticalY_BMGV2_BLTouch_LCDmini12864
   D3P_OCTOPUS_Driver2209BTT_OpticalY_BMGV3_BLTouch_LCDmini12864
-  D3P_OCTOPUS_Driver2208_UART_BLTouch_LCD_BTT_TFT 
 include_dir  = Marlin
 extra_configs =
     ini/avr.ini

--- a/scripts/name_build.sh
+++ b/scripts/name_build.sh
@@ -1,4 +1,4 @@
 cd ../.pio/
-find ./build -type f ! -name '*.hex' -delete
+find ./build -type f ! -name '*.hex' -type f ! -name '*.bin' -delete
 find ./build -type d -empty -delete
 mv build "build_ $(date +%Y%m%d_%H%M)"


### PR DESCRIPTION
Adds support for new builds.  Fixes rename script so that .bin files are not thrown out.